### PR TITLE
[BUG] When you type a country that you already typed, the ...

### DIFF
--- a/src/components/pages/GamePage/GuessInput.vue
+++ b/src/components/pages/GamePage/GuessInput.vue
@@ -9,10 +9,11 @@ import { useI18n } from 'vue-i18n'
 import type { MessageSchema } from '@/services/i18n'
 import Button from 'primevue/button'
 import { Icon } from '@iconify/vue'
+import type { Country } from '@/services/resources/country/types.ts'
 
 const guess = ref('')
 
-const duplicatedGuessedCountry = ref('')
+const duplicatedGuessedCountry = ref<Country | null>(null)
 
 const { t } = useI18n<{ message: MessageSchema }>()
 
@@ -32,13 +33,13 @@ function onKeyUp() {
   if (!(matchedCode.isoAlpha2Code in countryStore.guessedCountries))
     throw new Error(`${matchedCode.isoAlpha2Code} is not in countryStore.guessedCountries`)
 
-  duplicatedGuessedCountry.value = ''
+  duplicatedGuessedCountry.value = null
 
   if (countryStore.guessedCountries[matchedCode.isoAlpha2Code].guessedAt) {
     duplicatedGuessedCountry.value =
-      countryStore.guessedCountries[matchedCode.isoAlpha2Code].country.name
+      countryStore.guessedCountries[matchedCode.isoAlpha2Code].country
 
-    setTimeout(() => (duplicatedGuessedCountry.value = ''), 3000)
+    setTimeout(() => (duplicatedGuessedCountry.value = null), 3000)
 
     return
   }
@@ -108,7 +109,13 @@ function onGameRestartClick() {
         class="text-xs text-red-500"
         :class="[duplicatedGuessedCountry ? 'visible' : 'invisible']"
       >
-        {{ t('components.guess-input.country-duplicated', { country: duplicatedGuessedCountry }) }}
+        {{
+          duplicatedGuessedCountry
+            ? t('components.guess-input.country-duplicated', {
+                country: t(`common.countries.${duplicatedGuessedCountry.slug}`),
+              })
+            : '&nbsp;'
+        }}
       </div>
 
       <TimerSection />

--- a/src/services/i18n/lang/en.json
+++ b/src/services/i18n/lang/en.json
@@ -39,7 +39,8 @@
       "restart-game": "Restart game"
     },
     "timer-section": {
-      "no-time": "No time"
+      "no-time": "No time",
+      "restart-game": "Restart game"
     },
     "country-flag": {
       "flag": "Flag {country}"

--- a/src/services/i18n/lang/es.json
+++ b/src/services/i18n/lang/es.json
@@ -34,12 +34,13 @@
       "description": "Reiniciar el juego hará que pierdas tu progreso. ¿Estás seguro?"
     },
     "guess-input": {
-      "type-country-name": "Escribe el nombre de un país...",
+      "type-country-name": "Escribe un país...",
       "country-duplicated": "{country} ya fue ingresado",
       "restart-game": "Reiniciar juego"
     },
     "timer-section": {
-      "no-time": "Sin tiempo"
+      "no-time": "Sin tiempo",
+      "restart-game": "Reiniciar juego"
     },
     "country-flag": {
       "flag": "Bandera de {country}"

--- a/src/services/i18n/lang/pt.json
+++ b/src/services/i18n/lang/pt.json
@@ -39,7 +39,8 @@
       "restart-game": "Reiniciar jogo"
     },
     "timer-section": {
-      "no-time": "Sem tempo"
+      "no-time": "Sem tempo",
+      "restart-game": "Restart game"
     },
     "country-flag": {
       "flag": "Bandeira de {country}"


### PR DESCRIPTION
### Summary

Introduces a fix to the bug where the country name is displayed in English whenever it was typed twice.

### Setup

<!-- Steps to prepare for testing this PR -->

- Run `npm run dev`
- Start a game in Portuguese or Spanish
- Introduce a country
- Introduce the same country again
- The warning telling you the country was introduced twice should be translated

<!-- 

### Notes & Risks 

Explain key choices behind this implementation. 

- Chose Y over X due to Z 

-->
