### PR TITLE
[FEATURE] Possible to explore map after game finish

### DIFF
--- a/src/components/pages/GamePage/GuessInput.vue
+++ b/src/components/pages/GamePage/GuessInput.vue
@@ -73,7 +73,7 @@ function onGameRestartClick() {
   >
     <div
       v-if="countryStore.isShowingControls"
-      class="p-4 rounded-lg bg-(--p-inputtext-background) absolute top-5 left-1/2 -translate-x-1/2 w-64 px-4 py-2 shadow border border-(--p-inputtext-border-color) has-[input:focus]:border-(--p-inputtext-focus-border-color) transition-colors"
+      class="p-4 rounded-lg bg-(--p-inputtext-background) absolute top-5 left-1/2 -translate-x-1/2 w-64 px-4 py-2 shadow border border-(--p-inputtext-border-color) has-[input:focus]:border-(--p-inputtext-focus-border-color) transition-all"
       :class="[duplicatedGuessedCountry ? '!border-red-500' : '']"
     >
       <div class="flex justify-between items-center w-full">

--- a/src/components/pages/GamePage/ResultsDialog.vue
+++ b/src/components/pages/GamePage/ResultsDialog.vue
@@ -57,6 +57,11 @@ const titleModal = computed(() =>
     ? t('components.results-dialog.congratulations')
     : t('components.results-dialog.time-is-up'),
 )
+
+function onClickSeeMap() {
+  store.isResultsDialogOpen = false
+  store.isShowingShowResultsModalButton = true
+}
 </script>
 
 <template>
@@ -376,9 +381,18 @@ const titleModal = computed(() =>
     </section>
 
     <template #footer>
-      <Button class="w-full" severity="secondary" @click="store.onRestartGame">
-        {{ t('components.results-dialog.go-again') }}
-      </Button>
+      <Button
+        :label="t('components.results-dialog.see-map')"
+        class="w-full"
+        severity="secondary"
+        @click="onClickSeeMap"
+      />
+      <Button
+        :label="t('components.results-dialog.go-again')"
+        class="w-full"
+        severity="secondary"
+        @click="store.onRestartGame"
+      />
     </template>
   </Dialog>
 </template>

--- a/src/components/pages/GamePage/ShowResultsModalButton.vue
+++ b/src/components/pages/GamePage/ShowResultsModalButton.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import Button from 'primevue/button'
+import { useCountryStore } from '@/stores/countryStore.ts'
+import { useI18n } from 'vue-i18n'
+import type { MessageSchema } from '@/services/i18n'
+
+const { t } = useI18n<{ message: MessageSchema }>()
+
+const countryStore = useCountryStore()
+
+function onShowResultsClick() {
+  countryStore.isShowingShowResultsModalButton = false
+  countryStore.isResultsDialogOpen = true
+}
+</script>
+
+<template>
+  <transition
+    enter-active-class="transition transform duration-500 ease-out"
+    enter-from-class="-translate-y-10 opacity-0"
+    enter-to-class="translate-y-0 opacity-100"
+    leave-active-class="transition transform duration-300 ease-in"
+    leave-from-class="translate-y-0 opacity-100"
+    leave-to-class="-translate-y-10 opacity-0"
+  >
+    <div
+      v-if="countryStore.isShowingShowResultsModalButton"
+      class="p-4 flex flex-col gap-2 items-center rounded-lg bg-(--p-inputtext-background) absolute top-5 left-1/2 -translate-x-1/2 px-4 py-2 shadow border border-(--p-inputtext-border-color)"
+    >
+      {{ t('common.points', { count: countryStore.points }, countryStore.points) }}
+
+      <Button
+        :label="t('components.show-results-modal-button.show-results')"
+        severity="secondary"
+        variant="text"
+        size="small"
+        @click="onShowResultsClick"
+      />
+    </div>
+  </transition>
+</template>

--- a/src/components/pages/GamePage/StartGameModal.vue
+++ b/src/components/pages/GamePage/StartGameModal.vue
@@ -18,13 +18,20 @@ const classes = ref('')
 
 const isStarting = computed(() => counter.value >= 1)
 
-const timerOptions = computed(() => [
-  { value: null, text: t('components.start-game-modal.no-time') },
-  // { value: 5, text: t('common.xMinutes', { count: 0 }, 0) },
-  { value: 60, text: t('common.xMinutes', { count: 1 }, 1) },
-  { value: 300, text: t('common.xMinutes', { count: 5 }, 5) },
-  { value: 600, text: t('common.xMinutes', { count: 10 }, 10) },
-])
+const timerOptions = computed(() => {
+  const options = [
+    { value: null, text: t('components.start-game-modal.no-time') },
+    { value: 60, text: t('common.xMinutes', { count: 1 }, 1) },
+    { value: 300, text: t('common.xMinutes', { count: 5 }, 5) },
+    { value: 600, text: t('common.xMinutes', { count: 10 }, 10) },
+  ]
+
+  if (import.meta.env.DEV) {
+    options.push({ value: 1, text: '1 second (dev)' })
+  }
+
+  return options
+})
 
 const style = computed(() =>
   isStarting.value

--- a/src/pages/GamePage.vue
+++ b/src/pages/GamePage.vue
@@ -6,6 +6,7 @@ import GuessInput from '@/components/pages/GamePage/GuessInput.vue'
 import ResultsDialog from '@/components/pages/GamePage/ResultsDialog.vue'
 import { onMounted } from 'vue'
 import { useCountryStore } from '@/stores/countryStore.ts'
+import ShowResultsModalButton from '@/components/pages/GamePage/ShowResultsModalButton.vue'
 
 const countryStore = useCountryStore()
 
@@ -16,6 +17,7 @@ onMounted(() => {
 
 <template>
   <main class="relative w-full p-0 m-0 box-content">
+    <ShowResultsModalButton />
     <GuessInput />
     <ResultsDialog />
     <CountrySVG />

--- a/src/services/i18n/lang/en.json
+++ b/src/services/i18n/lang/en.json
@@ -20,6 +20,9 @@
     }
   },
   "components": {
+    "show-results-modal-button": {
+      "show-results": "Show results"
+    },
     "start-game-modal": {
       "title": "Configure your game",
       "description": "Pick all the options you would like to have in your game",
@@ -52,7 +55,8 @@
       "results-text": "You have named {totalGuess} countries out of {totalCountries} and made {points} points",
       "named-countries": "Named countries",
       "missing": "Missing countries",
-      "go-again": "Go again"
+      "go-again": "Go again",
+      "see-map": "See map"
     }
   },
   "common": {

--- a/src/services/i18n/lang/es.json
+++ b/src/services/i18n/lang/es.json
@@ -20,6 +20,9 @@
     }
   },
   "components": {
+    "show-results-modal-button": {
+      "show-results": "Mostrar resultados"
+    },
     "start-game-modal": {
       "title": "Configura tu juego",
       "description": "Elige todas las opciones que deseas tener en tu juego",
@@ -52,7 +55,8 @@
       "results-text": "Has nombrado {totalGuess} países de {totalCountries} y has ganado {points} puntos",
       "named-countries": "Países nombrados",
       "missing": "Países faltantes",
-      "go-again": "Intentar de nuevo"
+      "go-again": "Intentar de nuevo",
+      "see-map": "Ver mapa"
     }
   },
   "common": {

--- a/src/services/i18n/lang/pt.json
+++ b/src/services/i18n/lang/pt.json
@@ -20,6 +20,9 @@
     }
   },
   "components": {
+    "show-results-modal-button": {
+      "show-results": "Mostrar resultados"
+    },
     "start-game-modal": {
       "title": "Configure seu jogo",
       "description": "Escolha todas as opções que você gostaria de ter no jogo",
@@ -52,7 +55,8 @@
       "results-text": "Você digitou {totalGuess} países de um total de {totalCountries} e marcou {points} pontos",
       "named-countries": "Países digitados",
       "missing": "Países que faltaram",
-      "go-again": "Jogar novamente"
+      "go-again": "Jogar novamente",
+      "see-map": "Ver mapa"
     }
   },
   "common": {

--- a/src/stores/countryStore.ts
+++ b/src/stores/countryStore.ts
@@ -15,6 +15,8 @@ import { getPoints } from '@/services/resources/game/helpers.ts'
 export const useCountryStore = defineStore('countries', () => {
   const { locale } = useI18n()
 
+  const isShowingShowResultsModalButton = ref(false)
+
   const guessedCountries = ref<GuessedCountriesMap>(createGuessedCountriesMap(countries))
 
   const trieRoot = shallowRef(buildCountryTrie(countries, 'en'))
@@ -63,8 +65,8 @@ export const useCountryStore = defineStore('countries', () => {
   function onGameEnd() {
     endsAt.value = null
     isCounterFinishing.value = false
-    isResultsDialogOpen.value = true
     isShowingControls.value = false
+    isResultsDialogOpen.value = true
   }
 
   function onRestartGame() {
@@ -79,6 +81,7 @@ export const useCountryStore = defineStore('countries', () => {
   }
 
   return {
+    isShowingShowResultsModalButton,
     guessedCountries,
     latestCountryGuessed,
     endsAt,


### PR DESCRIPTION
### Summary

Introduces a button to `See map` when the user finishes the game

### Setup

<!-- Steps to prepare for testing this PR -->

- Run `npm run dev`
- Play the game
- On results modal, you should be able to see `See map`
- Click that button
- It should hide the results modal and you should be able to explore the map and your countries inserted

<!-- 

### Notes & Risks 

Explain key choices behind this implementation. 

- Chose Y over X due to Z 

-->
